### PR TITLE
update packaging to follow standard python practices

### DIFF
--- a/grain_size_tools/GrainSizeTools_script.py
+++ b/grain_size_tools/GrainSizeTools_script.py
@@ -30,9 +30,9 @@
 #                                                                              #
 # ============================================================================ #
 
-import plots as plots
-import tools as tools
-from piezometers import quartz, olivine, calcite, feldspar
+from . import plots
+from . import tools
+from .piezometers import quartz, olivine, calcite, feldspar
 import numpy as np
 from numpy import mean, sqrt, exp, log, log10, array, tan, arctan, delete
 from pandas import read_table, read_csv, read_excel, DataFrame

--- a/grain_size_tools/__init__.py
+++ b/grain_size_tools/__init__.py
@@ -1,0 +1,7 @@
+from . import piezometers
+from . import plots
+from . import tools
+from .GrainSizeTools_script import (
+    extract_column, area2diameter, calc_grain_size, Saltykov, calc_shape,
+    confidence_interval, calc_diffstress
+)

--- a/grain_size_tools/tools.py
+++ b/grain_size_tools/tools.py
@@ -31,7 +31,7 @@
 
 import os
 import numpy as np
-import plots as plots
+from . import plots
 from numpy import mean, std, median, sqrt, exp, log, delete
 from scipy.optimize import curve_fit
 from scipy.stats import gaussian_kde, iqr, mstats

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if (v[0] >= 3 and v[:2] < (3, 5)):
     print(error, file=sys.stderr)
     sys.exit(1)
 
-sys.path.append(os.path.join(sys.path[0], 'grain_size_tools'))
+# sys.path.append(os.path.join(sys.path[0], 'grain_size_tools'))
 
 setup(
     name="grain_size_tools",
@@ -30,7 +30,7 @@ setup(
     url="https://github.com/marcoalopez/GrainSizeTools",
     license=license,
     packages=find_packages(),
-    scripts=['grain_size_tools/GrainSizeTools_script.py', 'grain_size_tools/tools.py', 'grain_size_tools/plots.py', 'grain_size_tools/piezometers.py'],
+    # scripts=['grain_size_tools/GrainSizeTools_script.py', 'grain_size_tools/tools.py', 'grain_size_tools/plots.py', 'grain_size_tools/piezometers.py'],
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache-2.0 License",


### PR DESCRIPTION
This pr has a few updates to the packaging so that `grain_size_tools` can be imported as a standard python package (as discussed in marcoalopez/GrainSizeTools#8). After cloning the repository and running 
```
python setup.py install
```
The user can then run 
```
import grain_size_tools as gst
gst.extract_column()
```

This keeps the namespace cleaner so that all grain_size_tool functions are imported under the same namespace. In the code, I will add a few links and explanations. Please let me know if I can provide any clarification! 